### PR TITLE
Improvement/allow mapping as map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ const isNestedArray = arr => bool(
   arr.every(subArr => subArr.length === 2) // Every array inside has exactly 2 elements.
 )
 
+const isMap = m => bool(Object.prototype.toString.call(m) === '[object Map]')
+
 // Lifted from https://github.com/tj/co/blob/717b043371ba057cb7a4a2a4e47120d598116ed7/index.js#L221
 function isGeneratorFunction(obj) {
   const { constructor } = (obj || {})

--- a/src/index.js
+++ b/src/index.js
@@ -60,8 +60,8 @@ function sagaTestEngine(genFunc, envMapping, ...initialArgs) {
     isGeneratorFunction(genFunc),
     'The first parameter must be a generator function.')
   assert(
-    isNestedArray(envMapping),
-    'The second parameter must be a nested array.')
+    isMap(envMapping) || isNestedArray(envMapping),
+    'The second parameter must be a nested array or Map.')
 
   const mapping = [...envMapping, [undefined, undefined]]
   const gen = genFunc(...initialArgs)

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,15 @@ function assert(condition, message) {
 
 // Returns value in mapping corresponding to matching searchVal key.
 function getNextVal(searchVal, mapping) {
-  return (mapping.find(keyVal => deepEqual(keyVal[0], searchVal)) || [])[1]
+  if (isMap(mapping)) {
+    for (let [key, value] of mapping.entries()) {
+      if (deepEqual(key, searchVal)) {
+        return value
+      }
+    }
+  } else {
+    return (mapping.find(keyVal => deepEqual(keyVal[0], searchVal)) || [])[1]
+  }
 }
 
 function sagaTestEngine(genFunc, envMapping, ...initialArgs) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -63,6 +63,7 @@ test('isNestedArray correctly identifies a nested array', t => {
   t.false(isNestedArray([1, 2]))
   t.false(isNestedArray([[1], [2]]))
   t.false(isNestedArray([[1, 2], [3]]))
+  t.false(isNestedArray(new Map([[1, 2], [3]])))
 
   t.true(isNestedArray([]), 'Empty array is allowed.')
   t.true(isNestedArray([['key', 'val']]))
@@ -72,8 +73,10 @@ test('isNestedArray correctly identifies a nested array', t => {
 
 
 test('getNextVal', t => {
+  // Nested Array
   t.is(2, getNextVal(1, [[1, 2]]))
   t.is(2, getNextVal(1, [[1, 2], [1, 3]]))
+  t.is(4, getNextVal(3, [[1, 2], [3, 4]]))
   t.is(
     'val',
     getNextVal(
@@ -82,11 +85,50 @@ test('getNextVal', t => {
         [{a: {b: {c: 1}}}, 'val']
       ]
     ),
-    'Handled deeply-nested objects'
+    'Handled deeply-nested objects in arrays'
   )
+  t.is(
+    undefined,
+    getNextVal(
+      {a: {b: {c: 2}}},
+      [
+        [{a: {b: {c: 1}}}, 'val']
+      ]
+    ),
+    'Handled deeply-nested objects in arrays part 2'
+  )
+
+  // Map
+  t.is(2, getNextVal(1, new Map([[1, 2]])))
+  t.is(4, getNextVal(3, new Map([[1, 2], [3, 4]])))
+  t.is(
+    'val',
+    getNextVal(
+      {a: {b: {c: 1}}},
+      new Map([
+        [{a: {b: {c: 1}}}, 'val']
+      ])
+    ),
+    'Handled deeply-nested objects in Map'
+  )
+  t.is(
+    undefined,
+    getNextVal(
+      {a: {b: {c: 2}}},
+      new Map([
+        [{a: {b: {c: 1}}}, 'val']
+      ])
+    ),
+    'Handled deeply-nested objects in Map part 2'
+  )
+
+  // Handles value not found.
   t.is(undefined, getNextVal(100, []))
+  t.is(undefined, getNextVal(100, new Map([])))
   t.is(undefined, getNextVal(100, [[1, 2]]))
+  t.is(undefined, getNextVal(100, new Map([[1, 2]])))
   t.is(undefined, getNextVal(undefined, []))
+  t.is(undefined, getNextVal(undefined, new Map([])))
 })
 
 
@@ -113,10 +155,10 @@ test('sagaTestEngine throws under bad conditions', t => {
   // Second assert.
   t.throws(
     () => sagaTestEngine(genericGenFunc, 1),
-    'The second parameter must be a nested array.')
+    'The second parameter must be a nested array or Map.')
   t.throws(
     () => sagaTestEngine(genericGenFunc, [1]),
-    'The second parameter must be a nested array.')
+    'The second parameter must be a nested array or Map.')
 
   // Third assert.
   const f = function*() {

--- a/tests/index.js
+++ b/tests/index.js
@@ -284,3 +284,30 @@ test('Example favSagaWorker with sad path works', t => {
     'Not happy path'
   )
 })
+
+
+test('favSagaWorker works when given a Map', t => {
+  const itemId = '123'
+  const token = '456'
+  const user = {id: '321'}
+
+  const favItemResp = 'The favItem JSON response'
+  const favItemRespOBj = { json: () => favItemResp }
+
+  const FAV_ACTION = {
+    type: 'FAV_ITEM_REQUESTED',
+    payload: { itemId },
+  }
+
+  const ENV = new Map([
+    [select(getGlobalState), { user, token }],
+    [call(favItem, itemId, token), favItemRespOBj],
+    [favItemResp, favItemResp]
+  ])
+
+  t.deepEqual(
+    sagaTestEngine(favSagaWorker, ENV, FAV_ACTION),
+    [put(sucessfulFavItemAction(favItemResp, itemId, user))],
+    'Maps work'
+  )
+})


### PR DESCRIPTION
Allows `Map`s for second argument to main `sagaTestEngine` function.

Resolves issue https://github.com/DNAinfo/redux-saga-test-engine/issues/2