### PR TITLE
Add unit test for yield*

### DIFF
--- a/sagas/index.js
+++ b/sagas/index.js
@@ -11,6 +11,7 @@ const getGlobalState = () => ({
 const favItem = () => ({})
 const sucessfulFavItemAction = (...args) => args
 const receivedFavItemErrorAction = (...args) => args
+const loadingFavItemAction = (...args) => args
 
 // Example saga to be tested.
 function* favSagaWorker(action) {
@@ -31,5 +32,6 @@ module.exports = {
   getGlobalState,
   favItem,
   sucessfulFavItemAction,
-  receivedFavItemErrorAction
+  receivedFavItemErrorAction,
+  loadingFavItemAction
 }


### PR DESCRIPTION
Saw that #8 was still in TODO so I figured i'd lend a hand by adding a unit test. I'm loving using this library so far. My team at work was looking for a better way to test sagas and this has been a definite improvement. 

This PR adds unit tests to ensure that using `yield*` in a saga will function as expected by collecting the PUT actions from the yielded saga AND the saga called by test engine.