### PR TITLE
Log function info in env mapping error messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,20 @@ function getNextVal(searchVal, mapping) {
   }
 }
 
+// Used to stringify yielded values. Output includes functions
+function stringifyVal(val) {
+  return JSON.stringify(val, (key, val) => {
+    if (typeof val === 'function') {
+      if (val.name) {
+        return `[Function: ${val.name}]: ${val.toString()}`;
+      } else {
+        return `[Function]: ${val.toString()}`;
+      }
+    }
+    return val;
+  }, 2);
+}
+
 function sagaTestEngine(genFunc, envMapping, ...initialArgs) {
   assert(
     isGeneratorFunction(genFunc),
@@ -80,7 +94,7 @@ function sagaTestEngine(genFunc, envMapping, ...initialArgs) {
     const yieldedEffectIsPut = isPut(val) || isNestedPut(val)
     assert(
       (isFirstLoop || nextValFound || yieldedUndefined || yieldedEffectIsPut),
-      `Env Mapping is missing a value for ${JSON.stringify(val, null, 2)}`)
+      `Env Mapping is missing a value for ${stringifyVal(val)}`)
 
     const genResult = gen.next(nextVal)
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -170,35 +170,60 @@ test('sagaTestEngine throws under bad conditions', t => {
     () => sagaTestEngine(f, badMapping),
     'Env Mapping is missing a value for "key"')
 
+  // Bad mapping for saga that yields obj with anonymous function
+  function namedFunction() {}
+  const f2 = function*() {
+    yield { func: namedFunction }
+  }
+  const badMapping2 = [['bad', 'mapping']]
+  t.throws(
+    () => sagaTestEngine(f2, badMapping2),
+    `Env Mapping is missing a value for ${JSON.stringify({ "func": `[Function: namedFunction]: ${namedFunction.toString()}` }, null, 2)}`
+  )
+
+  // Bad mapping for saga that yields object with anonymous function
+  var anonymousFunction = function() { return 'something'; }
+  // Skip the anonymous function test if this anonymous functon is named (done in newer node versions)
+  if (!anonymousFunction.name) {
+    const f3 = function*() {
+      yield { func: anonymousFunction }
+    }
+    const badMapping3 = [['bad', 'mapping']]
+    t.throws(
+      () => sagaTestEngine(f3, badMapping3),
+      `Env Mapping is missing a value for ${JSON.stringify({ func: `[Function]: ${anonymousFunction.toString()}` }, null, 2)}`
+    )
+  }
+
   // No errors thrown
   const goodMapping = [['key', 'value']]
   t.notThrows(() => sagaTestEngine(f, goodMapping))
 
-  const f2 = function*() {
+  const f4 = function*() {
     yield 'key1'
     yield 'key2'
   }
   const goodMapping2 = [['key1', 'value1'], ['key2', 'value2']]
-  t.notThrows(() => sagaTestEngine(f2, goodMapping2))
+  t.notThrows(() => sagaTestEngine(f4, goodMapping2))
 
-  const f3 = function*() {
+  const f5 = function*() {
     yield undefined
   }
   const goodMapping3 = [[undefined, undefined]]
-  t.notThrows(() => sagaTestEngine(f3, goodMapping3))
+  t.notThrows(() => sagaTestEngine(f5, goodMapping3))
 
-  const f4 = function*() {
+  const f6 = function*() {
     yield [put({a: 1})]
   }
   t.notThrows(
-    () => sagaTestEngine(f4, goodMapping3),
+    () => sagaTestEngine(f6, goodMapping3),
     'Correctly handles nested array of puts'
   )
 
-  const f5 = function*() {
+  const f7 = function*() {
     yield [select(() => 1)]
   }
-  t.throws(() => sagaTestEngine(f5, goodMapping3))
+  t.throws(() => sagaTestEngine(f7, goodMapping3))
 })
 
 


### PR DESCRIPTION
### Problem
When a yielded value is not found in envMapping, the entire `val` is printed to the console via `JSON.stringify`, which, by default, does not output a key/value pair when the value is a function. Without information about the function being output in the error message, it's more difficult to track down what the missing mapping is.

### Fix
Updated the `JSON.stringify` call to use a custom replacer that outputs the function name or info about the anonymous function.

```
Env Mapping is missing a value for {
  "select": "[Function: namedFunction]: function namedFunction() {/* function definition */}"
}
```

```
Env Mapping is missing a value for {
  "func": "[Function]: function () {/* function definition */}"
}
```