### PR TITLE
Add mechanism to instruct test engine to throw error

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -1,11 +1,12 @@
 'use strict'
 
 const {
-    collectPuts,
-    collectCalls,
-    collectCallsAndPuts,
-    createSagaTestEngine,
-} = require('./index')
+  throwError,
+  collectPuts,
+  collectCalls,
+  collectCallsAndPuts,
+  createSagaTestEngine,
+} = require('./src')
 
 module.exports = {
   default: createSagaTestEngine,
@@ -13,4 +14,5 @@ module.exports = {
   collectPuts,
   collectCalls,
   collectCallsAndPuts,
+  throwError,
 }

--- a/src/entry.js
+++ b/src/entry.js
@@ -1,12 +1,12 @@
 'use strict'
 
 const {
-  throwError,
   collectPuts,
   collectCalls,
   collectCallsAndPuts,
   createSagaTestEngine,
-} = require('./src')
+  throwError,
+} = require('./index')
 
 module.exports = {
   default: createSagaTestEngine,

--- a/src/index.js
+++ b/src/index.js
@@ -25,9 +25,10 @@ const isNestedArray = arr => bool(
 const isMap = m => bool(Object.prototype.toString.call(m) === '[object Map]')
 
 // check if consumer is yielding our effect to immediatly cause the generator function to throw an error
-const shouldThrowError = obj => bool(obj && Object.keys(obj).includes('@THROW'))
+const shouldThrowError = obj => bool(obj && Object.keys(obj)
+  .includes('@@redux-saga-test-engine/ERROR'))
 
-const throwError = message => ({ '@THROW': message })
+const throwError = message => ({ '@@redux-saga-test-engine/ERROR': message })
 
 // Lifted from https://github.com/tj/co/blob/717b043371ba057cb7a4a2a4e47120d598116ed7/index.js#L221
 function isGeneratorFunction(obj) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -130,7 +130,7 @@ test('shouldThrowError correctly identifies a throw effect', t => {
   t.false(shouldThrowError({ PUT: 'someting' }))
 
   t.true(shouldThrowError(throwError('error')))
-  t.true(shouldThrowError({ '@THROW': 'someting' }))
+  t.true(shouldThrowError({ '@@redux-saga-test-engine/ERROR': 'someting' }))
 })
 
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -9,6 +9,8 @@ const {
   isNestedArray,
   getNextVal,
   isNestedEffect,
+  throwError,
+  shouldThrowError,
 } = require('../src')
 const {
   favSagaWorker,
@@ -113,6 +115,22 @@ test('isNestedArray correctly identifies a nested array', t => {
   t.true(isNestedArray([['key', 'val']]))
   t.true(isNestedArray([['key', 'val']]))
   t.true(isNestedArray([[undefined, undefined]]))
+})
+
+test('shouldThrowError correctly identifies a throw effect', t => {
+  t.false(shouldThrowError())
+  t.false(shouldThrowError({}))
+  t.false(shouldThrowError(put))
+  t.false(shouldThrowError(call))
+  t.false(shouldThrowError(select))
+  t.false(shouldThrowError(call(() => 'call')))
+  t.false(shouldThrowError(select(() => 'select')))
+  t.false(shouldThrowError({ CALL: 'someting' }))
+  t.false(shouldThrowError(put({})))
+  t.false(shouldThrowError({ PUT: 'someting' }))
+
+  t.true(shouldThrowError(throwError('error')))
+  t.true(shouldThrowError({ '@THROW': 'someting' }))
 })
 
 
@@ -349,6 +367,30 @@ test('Example favSagaWorker with sad path works', t => {
   t.deepEqual(
     sagaTestEngine(favSagaWorker, ENV, FAV_ACTION),
     [put(receivedFavItemErrorAction(favItemRespFail, itemId))],
+    'Not happy path'
+  )
+})
+
+
+test('Example favSagaWorker with throwError effect follows sad path', t => {
+  const itemId = '123'
+  const token = '456'
+  const user = { id: '321' }
+  const errorMsg = 'ERROR'
+
+  const FAV_ACTION = {
+    type: 'FAV_ITEM_REQUESTED',
+    payload: { itemId },
+  }
+
+  const ENV = [
+    [select(getGlobalState), { user, token }],
+    [call(favItem, itemId, token), throwError(errorMsg)],
+  ]
+
+  t.deepEqual(
+    sagaTestEngine(favSagaWorker, ENV, FAV_ACTION),
+    [put(receivedFavItemErrorAction(errorMsg, itemId))],
     'Not happy path'
   )
 })


### PR DESCRIPTION
Handles @CoryDanielson's request in #15 

- Expose `throwError` as a faux-effect that returns an object with a key `@THROW` and an error message
- In the test engine, if we see a value that matches throwError we can instruct the generator to throw
- This lets consumers explicitly define that they want the generator to error out in their mappings instead of writing a value that will cause an error indirectly (like in this unit test: https://github.com/DNAinfo/redux-saga-test-engine/blob/master/tests/index.js#L336)