### PR TITLE
Don't publish .babelrc to NPM for React Native compatibility

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 src
 tests
+.babelrc


### PR DESCRIPTION
Fixes issues for React Native users of this library: https://github.com/DNAinfo/redux-saga-test-engine/issues/28 https://github.com/DNAinfo/redux-saga-test-engine/issues/26

I think React Native has some issues with 3rd party modules containing their own `.babelrc` (https://github.com/airbnb/react-native-maps/issues/795#issuecomment-289828439). The fix for this is to just not publish it to NPM! There's really no need to be publishing this out in the wild, so i think there's no risk to doing this.