### PR TITLE
Improvement/Remove node v6 requirement from pkgjson

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,3 +2,6 @@ test:
   override:
     - nvm install stable && nvm alias default stable
     - npm test
+machine:
+  node:
+    version: 6.0.0

--- a/package.json
+++ b/package.json
@@ -2,12 +2,6 @@
   "name": "redux-saga-test-engine",
   "version": "2.0.3",
   "description": "Redux saga test helper",
-  "engines": {
-    "node": ">=6.0.0"
-  },
-  "engine": {
-    "node": ">=6.0.0"
-  },
   "main": "build/index.js",
   "repository": "DNAinfo/redux-saga-test-engine",
   "scripts": {


### PR DESCRIPTION
This should remove the node version 6 requirement warning seen during `npm install`/`yarn`, while still preserving the minimum node requirement when CircleCI is running tests.