### PR TITLE
Support for testing sagas that are expected to throw exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Test your `redux-saga` generator functions with less pain.
     - [Q: Why not just use redux-saga-test-plan?](#q-why-not-just-use-redux-saga-test-plan)
     - [Q: Why not just do it manually?](#q-why-not-just-do-it-manually-example)
     - [Q: Why not use a Map for the second argument (the envMapping)?](#q-why-not-use-a-map-for-the-second-argument-the-envmapping)
+    - [Q: How to test saga that is expected to throw exception?](#how-to-test-saga-that-is-expected-to-throw-exception)
     - [Q: I know a better way](#q-i-know-a-better-way)
   - [License](#license)
 
@@ -265,6 +266,41 @@ it('should cancel login task', () => {
 _**NOTE**: The collector functions now accept a `Map` as well as a nested array. But it isn't actually helpful, as described below._
 
 Maps only work if the key is referencing the identical object (ie `a === b`), even if their values are the same (ie `deepEqual(a, b)`). Thus a corresponding `select(...)` value, for example, would not be found merely by using `envMap.get(select(...))`. Instead, the keys must be traversed though - and so it's no more helpful to use a Map than a simple nested Array.
+
+### Q: How to test saga that is expected to throw exception?
+**A**: In some cases is useful saga to throw exception, for example when is part of bigger composed saga chain. As this library is testing framework agnostic it should propagate saga exceptions up and this makes no longer possible to receive collected 'PUT's as function result. To solve this problem we can pass empty `collected` array as argument to `collectPuts` function and inspect his content after the test run. The second argument (the `envMapping`) can accept `options` object, see the following 'ava' test example:
+
+```js
+test('Example throwFavSagaWorker with throwError effect follows sad path', t => {
+  const FAV_ACTION = {
+    type: 'FAV_ITEM_REQUESTED',
+    payload: { itemId: 123 },
+  }
+
+  const mapping = [
+    [call(favItem, itemId, token), throwError('ERROR')],
+  ]
+
+  // empty array reference
+  const collected = []
+
+  const options = {
+    mapping,
+    collected,
+  }
+
+  // expect to throw exception
+  t.throws(() => {
+    collectPuts(throwFavSagaWorker, options, FAV_ACTION)
+  })
+
+  t.deepEqual(
+    collected,
+    [put(receivedFavItemErrorAction('ERROR', 123))],
+    'Not happy path'
+  )
+})
+```
 
 ### Q: I know a better way.
 **A**: Awesome, please show us!

--- a/sagas/index.js
+++ b/sagas/index.js
@@ -28,6 +28,20 @@ function* favSagaWorker(action) {
   }
 }
 
+function* throwFavSagaWorker(action) {
+  const { itemId } = action.payload
+  const { token, user } = yield select(getGlobalState)
+
+  try {
+    const response = yield call(favItem, itemId, token)
+    const json = yield response.json()
+    yield put(sucessfulFavItemAction(json, itemId, user))
+  } catch (e) {
+    yield put(receivedFavItemErrorAction(e, itemId))
+    throw e
+  }
+}
+
 function* retryFavSagaWorker(action) {
   const { itemId } = action.payload
   const { token, user } = yield select(getGlobalState)
@@ -62,6 +76,7 @@ function* sagaWithNestedSaga(action) {
 
 module.exports = {
   favSagaWorker,
+  throwFavSagaWorker,
   retryFavSagaWorker,
   sagaWithNoPuts,
   sagaWithNestedSaga,


### PR DESCRIPTION
### Q: How to test saga that is expected to throw exception?
**A**: In some cases is useful saga to throw exception, for example when is part of bigger composed saga chain. As this library is testing framework agnostic it should propagate saga exceptions up and this makes no longer possible to receive collected 'PUT's as function result. To solve this problem we can pass empty `collected` array as argument to `collectPuts` function and inspect his content after the test run. The second argument (the `envMapping`) can accept `options` object, see the following 'ava' test example:

```js
test('Example throwFavSagaWorker with throwError effect follows sad path', t => {
  const FAV_ACTION = {
    type: 'FAV_ITEM_REQUESTED',
    payload: { itemId: 123 },
  }

  const mapping = [
    [call(favItem, itemId, token), throwError('ERROR')],
  ]

  // empty array reference
  const collected = []

  const options = {
    mapping,
    collected,
  }

  // expect to throw exception
  t.throws(() => {
    collectPuts(throwFavSagaWorker, options, FAV_ACTION)
  })

  t.deepEqual(
    collected,
    [put(receivedFavItemErrorAction('ERROR', 123))],
    'Not happy path'
  )
})
```